### PR TITLE
Adding page tracking

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -53,6 +53,7 @@ class PDFDocument extends stream.Readable {
 
     this._pageBuffer = [];
     this._pageBufferStart = 0;
+    this._currentPageIndex; //undefined if not swapped otherwise we need to track page
 
     // The PDF object store
     this._offsets = [];
@@ -142,8 +143,13 @@ class PDFDocument extends stream.Readable {
 
     // create a page object
     this.page = new PDFPage(this, options);
-    this._pageBuffer.push(this.page);
-
+    
+    if (this._currentPageIndex) {
+        this._currentPageIndex++;
+        this._pageBuffer.splice(this._currentPageIndex, 0, this.page);
+    } else {
+        this._pageBuffer.push(this.page);
+    }
     // add the page to the object store
     const pages = this._root.data.Pages.data;
     pages.Kids.push(this.page.dictionary);
@@ -186,6 +192,8 @@ class PDFDocument extends stream.Readable {
         } to ${this._pageBufferStart + this._pageBuffer.length - 1}`
       );
     }
+
+    this._currentPageIndex = n;
 
     return (this.page = page);
   }


### PR DESCRIPTION
Currently switching pages only swaps it for any page specific changes required. Adding in to track the current page once swapped so that things like adding a table of contents or other pages mid document are feasible. Currently it will always add a new page to the end of the document which if pages are swapped is not ideal

<!--
Please make sure you are familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- Is it a Bug fix, feature, docs update, ... -->
<!-- You can also link to an open issue here -->
**What kind of change does this PR introduce?**


<!-- Have you done all of these things?  -->
**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Unit Tests
- [ ] Documentation
- [ ] Update CHANGELOG.md
- [ ] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
